### PR TITLE
fix: upgrade action runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -282,5 +282,5 @@ branding:
   icon: 'box'
   color: 'gray-dark'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

One-line change: `using: 'node20'` → `using: 'node24'` in `action.yml`.

The GitHub Actions runner is deprecating Node.js 20 on **June 2nd, 2026**. All g-01 build workflows use `kooply/unity-builder@slow-build` and the current `node20` runtime will trigger forced migration (and potential breakage) at that deadline.

The upstream `game-ci/unity-builder` already ships `node24` on their main branch. This change brings the `slow-build` branch in line without touching any other code — the full rebase from upstream is a separate, larger effort.

## Test plan

- [ ] Merge and retrigger a g-01 Android build on `kooply/unity-builder@slow-build`
- [ ] Confirm no Node.js 20 deprecation warning for `unity-builder` in the build log

Requested by: Ido Schwartzman
Slack thread: https://kooplyworkspace.slack.com/messages/C0545S8CDFH/p1778071099288509?thread_ts=1778071099.288509