### PR TITLE
fix: upgrade action runtime from node20 to node24 (main branch)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -282,5 +282,5 @@ branding:
   icon: 'box'
   color: 'gray-dark'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Same 1-line fix as #10 (which went to `slow-build`), now targeting `main`.

g-01 workflows were switched to `@main` assuming it already had `node24`, but `main` still had `node20`. This brings main into sync.

Requested by: Ido Schwartzman