### PR TITLE
fix: pin i18n < 1.15 to avoid Ruby 3.1 incompatibility (Ido)

### DIFF
--- a/dist/platforms/ubuntu/steps/cocoapods.sh
+++ b/dist/platforms/ubuntu/steps/cocoapods.sh
@@ -28,6 +28,7 @@ echo "==================== Selecting Ruby ======================="
 rvm --default use ruby-3.1.0
 
 echo "==================== Installing Cocoa Pods ======================="
+gem install i18n -v '< 1.15'
 gem install cocoapods
 
 # seems thet cocoapods really wants rsync
@@ -40,5 +41,3 @@ export COCOAPODS_ALLOW_ROOT=1
 pod setup --allow-root
 
 which pod
-
-


### PR DESCRIPTION
## Intent
- **Original ask:** iOS builds breaking because pod install fails on Linux due to i18n 1.15.0 incompatibility with Ruby 3.1
- **Key decisions:** Pin `i18n < 1.15` via `gem install i18n -v '< 1.15'` before `gem install cocoapods`, so the dependency resolver picks up 1.14.x which works with Ruby 3.1.0
- **Root cause:** i18n 1.15.0 was published to RubyGems on 2026-06-16/17 and uses `Fiber[:key]` syntax (Ruby 3.2+). rc6 installed i18n 1.14.8 and worked; rc7+ installed i18n 1.15.0 and broke.
- **Alternatives considered:** Upgrading Ruby from 3.1.0 to 3.2+ (more invasive); constraining via Gemfile (not available here)
- **Known limitations:** Will need re-pinning if i18n 1.16+ has the same issue, but that's unlikely as they'll fix the compatibility

## Summary
- One-line add: `gem install i18n -v '< 1.15'` before `gem install cocoapods`
- `cocoapods.sh` runs fresh on every build so this takes effect immediately

## Test plan
- [ ] Merge and trigger iOS build — pod install should return `True after 1 attempts` (as in rc6)

---
Requested by: Ido Schwartzman
`slack` thread: https://kooplyworkspace.slack.com/messages/C0545S8CDFH/p1781697945959559?thread_ts=1781697945.959559